### PR TITLE
Keep original file mode when overwriting

### DIFF
--- a/atomicwrites/__init__.py
+++ b/atomicwrites/__init__.py
@@ -20,6 +20,8 @@ def _path_to_unicode(x):
 
 if sys.platform != 'win32':
     def _replace_atomic(src, dst):
+        if os.path.exists(dst):
+            os.chmod(src, os.stat(dst).st_mode)
         os.rename(src, dst)
 
     def _move_atomic(src, dst):

--- a/tests/test_atomicwrites.py
+++ b/tests/test_atomicwrites.py
@@ -44,7 +44,7 @@ def test_replace_simultaneously_created_file(tmpdir):
 def test_replace_keep_mode_unchanged(tmpdir):
     fname = tmpdir.join('ha')
     fname.write('abc')
-    os.chmod(str(fname), 0640)
+    os.chmod(str(fname), 0o640)
     f_mode_before = os.stat(str(fname)).st_mode
     with atomic_write(str(fname), overwrite=True) as f:
         f.write('hoho')

--- a/tests/test_atomicwrites.py
+++ b/tests/test_atomicwrites.py
@@ -1,3 +1,4 @@
+import os
 import errno
 
 from atomicwrites import atomic_write
@@ -38,6 +39,17 @@ def test_replace_simultaneously_created_file(tmpdir):
         assert fname.read() == 'harhar'
     assert fname.read() == 'hoho'
     assert len(tmpdir.listdir()) == 1
+
+
+def test_replace_keep_mode_unchanged(tmpdir):
+    fname = tmpdir.join('ha')
+    fname.write('abc')
+    os.chmod(str(fname), 0640)
+    f_mode_before = os.stat(str(fname)).st_mode
+    with atomic_write(str(fname), overwrite=True) as f:
+        f.write('hoho')
+    f_mode_after = os.stat(str(fname)).st_mode
+    assert f_mode_before == f_mode_after
 
 
 def test_dont_remove_simultaneously_created_file(tmpdir):


### PR DESCRIPTION
Hi, a stumbled across a bug, when after I call `atomic_write` with overwrite=True, I got file with a different mode than before.
