### PR TITLE
Make atomic_write work on paths with no directory separator

### DIFF
--- a/atomicwrites/__init__.py
+++ b/atomicwrites/__init__.py
@@ -22,18 +22,6 @@ def _path_to_unicode(x):
     return x
 
 
-def dirname(p):
-    '''Like os.path.dirname but returns '.' in place of ''.
-
-    Compare: os.path.dirname('hello.txt'), dirname('hello.txt').
-
-    '''
-    dn = os.path.dirname(p)
-    if dn == '':
-        return '.'
-    else:
-        return dn
-
 _proper_fsync = os.fsync
 
 
@@ -55,14 +43,14 @@ if sys.platform != 'win32':
 
     def _replace_atomic(src, dst):
         os.rename(src, dst)
-        _sync_directory(dirname(dst))
+        _sync_directory(os.path.normpath(os.path.dirname(dst)))
 
     def _move_atomic(src, dst):
         os.link(src, dst)
         os.unlink(src)
 
-        src_dir = dirname(src)
-        dst_dir = dirname(dst)
+        src_dir = os.path.normpath(os.path.dirname(src))
+        dst_dir = os.path.normpath(os.path.dirname(dst))
         _sync_directory(dst_dir)
         if src_dir != dst_dir:
             _sync_directory(src_dir)
@@ -173,7 +161,7 @@ class AtomicWriter(object):
     def get_fileobject(self, dir=None, **kwargs):
         '''Return the temporary file to use.'''
         if dir is None:
-            dir = dirname(self._path)
+            dir = os.path.normpath(os.path.dirname(self._path))
         return tempfile.NamedTemporaryFile(mode=self._mode, dir=dir,
                                            delete=False, **kwargs)
 

--- a/atomicwrites/__init__.py
+++ b/atomicwrites/__init__.py
@@ -22,6 +22,18 @@ def _path_to_unicode(x):
     return x
 
 
+def dirname(p):
+    '''Like os.path.dirname but returns '.' in place of ''.
+
+    Compare: os.path.dirname('hello.txt'), dirname('hello.txt').
+
+    '''
+    dn = os.path.dirname(p)
+    if dn == '':
+        return '.'
+    else:
+        return dn
+
 _proper_fsync = os.fsync
 
 
@@ -43,14 +55,14 @@ if sys.platform != 'win32':
 
     def _replace_atomic(src, dst):
         os.rename(src, dst)
-        _sync_directory(os.path.dirname(dst))
+        _sync_directory(dirname(dst))
 
     def _move_atomic(src, dst):
         os.link(src, dst)
         os.unlink(src)
 
-        src_dir = os.path.dirname(src)
-        dst_dir = os.path.dirname(dst)
+        src_dir = dirname(src)
+        dst_dir = dirname(dst)
         _sync_directory(dst_dir)
         if src_dir != dst_dir:
             _sync_directory(src_dir)
@@ -161,7 +173,7 @@ class AtomicWriter(object):
     def get_fileobject(self, dir=None, **kwargs):
         '''Return the temporary file to use.'''
         if dir is None:
-            dir = os.path.dirname(self._path)
+            dir = dirname(self._path)
         return tempfile.NamedTemporaryFile(mode=self._mode, dir=dir,
                                            delete=False, **kwargs)
 

--- a/tests/test_atomicwrites.py
+++ b/tests/test_atomicwrites.py
@@ -69,7 +69,7 @@ def test_open_reraise(tmpdir):
 
 
 def test_atomic_write_in_pwd(tmpdir):
-    orig_curdir= os.getcwd()
+    orig_curdir = os.getcwd()
     try:
         os.chdir(str(tmpdir))
         fname = 'ha'

--- a/tests/test_atomicwrites.py
+++ b/tests/test_atomicwrites.py
@@ -71,7 +71,7 @@ def test_open_reraise(tmpdir):
 def test_atomic_write_in_pwd(tmpdir):
     orig_curdir= os.getcwd()
     try:
-        os.chdir(tmpdir)
+        os.chdir(str(tmpdir))
         fname = 'ha'
         for i in range(2):
             with atomic_write(str(fname), overwrite=True) as f:
@@ -83,7 +83,7 @@ def test_atomic_write_in_pwd(tmpdir):
 
         assert excinfo.value.errno == errno.EEXIST
 
-        assert fname.read() == 'hoho'
+        assert open(fname).read() == 'hoho'
         assert len(tmpdir.listdir()) == 1
     finally:
         os.chdir(orig_curdir)

--- a/tests/test_atomicwrites.py
+++ b/tests/test_atomicwrites.py
@@ -1,4 +1,5 @@
 import errno
+import os
 
 from atomicwrites import atomic_write
 
@@ -68,7 +69,7 @@ def test_open_reraise(tmpdir):
 
 
 def test_atomic_write_in_pwd(tmpdir):
-    curdir= os.getcwd()
+    orig_curdir= os.getcwd()
     try:
         os.chdir(tmpdir)
         fname = 'ha'
@@ -85,4 +86,4 @@ def test_atomic_write_in_pwd(tmpdir):
         assert fname.read() == 'hoho'
         assert len(tmpdir.listdir()) == 1
     finally:
-        os.chdir(curdir)
+        os.chdir(orig_curdir)


### PR DESCRIPTION
Fixes #19, and adds a test for it.

(I wasn't able to figure out how to actually run the tests, so you'll have to check that my test actually works.)
