### PR TITLE
Add mypy type annotations

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,6 @@
+[mypy]
+fast_parser = True
+silent_imports = True
+check_untyped_defs = True
+warn_redundant_casts = True
+disallow_untyped_defs = True

--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,5 @@ setup(
     long_description=open('README.rst').read(),
     packages=find_packages(exclude=['tests.*', 'tests']),
     include_package_data=True,
+    install_requires=['typing'],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,15 @@
 [tox]
-envlist = py{26,27,py,33,34,35}-{test,stylecheck}
+envlist = py{26,27,py,33,34,35}-{test,stylecheck},py{33,34,35}-typecheck
 
 [testenv]
 deps =
+    typing
     test: pytest
     stylecheck: flake8
     stylecheck: flake8-import-order
+    typecheck: mypy-lang
+    typecheck: typed-ast
 commands =
     test: py.test []
     stylecheck: flake8 []
+    typecheck: mypy atomicwrites


### PR DESCRIPTION
So, I've been playing with the MyPy static type checker lately, and I decided spend some downtime adding type annotations to Python projects I've worked on.

I had to change the logic a bit in order to make the code type check successfully, mainly by more eagerly converting a "unicode or bytes" path to unambiguously unicode when the object is constructed.

I also made it so that `tox -e py-typecheck` will run the type checker.