### PR TITLE
Add python 3.5 and 3.6 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ python:
     - "pypy"
     - "3.3"
     - "3.4"
+    - 3.5
+    - 3.6
+    - pypy3.3-5.2-alpha1
 
 install:
     - # The OS X VM doesn't have any Python support at all

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,37 +2,39 @@ sudo: false
 os: linux
 language: python
 
-matrix:
-    include:
-        - os: osx
-          language: generic
-          env: TOXENV_SUFFIX=test
-
 python:
-    - "2.6"
-    - "2.7"
-    - "pypy"
-    - "3.3"
-    - "3.4"
+    - 2.6
+    - 2.7
+    - pypy
+    - 3.3
+    - 3.4
     - 3.5
     - 3.6
     - pypy3.3-5.2-alpha1
 
+env:
+    - TOXENV=test
+
+matrix:
+    include:
+        - # The OS X VM doesn't have any Python support at all
+          # See https://github.com/travis-ci/travis-ci/issues/2312
+          os: osx
+          language: generic
+          env: TOXENV=test
+          before_install:
+            - brew update
+            - brew install python3
+            - virtualenv $HOME/osx-py3 -p python3
+            - source $HOME/osx-py3/bin/activate
+        - python: 2.7
+          env: TOXENV=stylecheck
+        - python: 3.6
+          env: TOXENV=stylecheck
+
+
 install:
-    - # The OS X VM doesn't have any Python support at all
-      # See https://github.com/travis-ci/travis-ci/issues/2312
-      if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-          brew update;
-          brew install python3;
-          virtualenv -p python3 $HOME/osx-py3;
-          . $HOME/osx-py3/bin/activate;
-          export TRAVIS_PYTHON_VERSION="$(python --version | cut -d ' ' -f 2 | cut -d . -f -2)";
-      fi
     - pip install tox
 
 script:
-    - export TOX_PY="$(echo py$TRAVIS_PYTHON_VERSION | tr -d . | sed -e 's/pypypy/pypy/')"
-    - tox -e $TOX_PY-test
-    - if [ "$TRAVIS_PYTHON_VERSION" = "2.7" ] || [ "$TRAVIS_PYTHON_VERSION" = ".3.5" ]; then
-          tox -e $TOX_PY-stylecheck;
-      fi
+    - tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@ environment:
     - PYTHON: "C:/Python27"
     - PYTHON: "C:/Python33"
     - PYTHON: "C:/Python34"
+    - PYTHON: "C:/Python35"
+    - PYTHON: "C:/Python36"
 
 init:
   - "ECHO %PYTHON%"


### PR DESCRIPTION
Fun fact: flake was set to run with python 2.7 and 3.5, but 3.5 was not in the build matrix.

Also did some simplification, since we could remove some conditionals, variable, etc.