### PR TITLE
try to use os.replace instead of os.rename whenever possible

### DIFF
--- a/atomicwrites/__init__.py
+++ b/atomicwrites/__init__.py
@@ -42,7 +42,10 @@ if sys.platform != 'win32':
             os.close(fd)
 
     def _replace_atomic(src, dst):
-        os.rename(src, dst)
+        try:
+            os.replace(src, dst)
+        except:
+            os.rename(src, dst)
         _sync_directory(os.path.normpath(os.path.dirname(dst)))
 
     def _move_atomic(src, dst):


### PR DESCRIPTION
I'm using this lib on Windows 10 with no issues so far, but I'm affraid os.rename, though not well documented for Windows, isn't atomic. As per the documentation:

> If you want cross-platform overwriting of the destination, use replace().
https://docs.python.org/3/library/os.html#os.rename

So I suggest something along the lines of:

```
def _replace_atomic(src, dst):
        try:
                os.replace(src, dst)
        except:
                os.rename(src, dst)
        _sync_directory(os.path.normpath(os.path.dirname(dst)))
```