### PR TITLE
Remove non-existent _static dir from docs/conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,7 @@ pygments_style = 'sphinx'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 
 # Output file base name for HTML help builder.


### PR DESCRIPTION
To prevent the following warning:
```
copying static files... WARNING: html_static_path entry '/var/tmp/portage/dev-python/atomicwrites-1.1.5-r3/work/atomicwrites-1.1.5/docs/_static' does not exist                                                   ```