### PR TITLE
Update supported Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os: linux
 language: python
 
 python:
-    - 2.6
     - 2.7
     - pypy
     - 3.4

--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,15 @@ setup(
     long_description=open('README.rst').read(),
     packages=find_packages(exclude=['tests.*', 'tests']),
     include_package_data=True,
+    classifiers=[
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: CPython',
+    ],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{26,27,py,33,34,35}-{test,stylecheck}
+envlist = py{27,py,34,35,36}-{test,stylecheck}
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 2.6 and 3.3 are EOL and no longer receiving security updates (or any updates) from the core Python team.

They're also little used.

Here's the pip installs for atomicwrites from PyPI for June 2018:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 3.6            |  72.14% |        878,675 |
| 2.7            |  19.73% |        240,284 |
| 3.5            |   5.87% |         71,478 |
| 3.4            |   1.92% |         23,405 |
| 3.7            |   0.30% |          3,703 |
| 3.3            |   0.03% |            354 |
| 2.6            |   0.01% |            139 |
| 3.8            |   0.00% |             31 |
| 3.2            |   0.00% |              8 |
| None           |   0.00% |              6 |
| Total          |         |      1,218,083 |

Source: `pypinfo --start-date 2018-06-01 --end-date 2018-06-30 --percent --markdown atomicwrites pyversion`

This also adds Trove classifiers, and `python_requires` to help pip.