### PR TITLE
Passes kwargs through AtomicWriter and uses io.open as opener

### DIFF
--- a/atomicwrites/__init__.py
+++ b/atomicwrites/__init__.py
@@ -1,4 +1,5 @@
 import contextlib
+import io
 import os
 import sys
 import tempfile
@@ -118,7 +119,7 @@ class AtomicWriter(object):
     subclass.
     '''
 
-    def __init__(self, path, mode='w', overwrite=False, **tempfile_kwargs):
+    def __init__(self, path, mode='w', overwrite=False, **open_kwargs):
         if 'a' in mode:
             raise ValueError(
                 'Appending to an existing file is not supported, because that '
@@ -134,7 +135,7 @@ class AtomicWriter(object):
         self._path = path
         self._mode = mode
         self._overwrite = overwrite
-        self._tempfile_kwargs = tempfile_kwargs
+        self._open_kwargs = open_kwargs
 
     def open(self):
         '''
@@ -147,7 +148,7 @@ class AtomicWriter(object):
         f = None  # make sure f exists even if get_fileobject() fails
         try:
             success = False
-            with get_fileobject(**self._tempfile_kwargs) as f:
+            with get_fileobject(**self._open_kwargs) as f:
                 yield f
                 self.sync(f)
             self.commit(f)
@@ -163,10 +164,14 @@ class AtomicWriter(object):
         '''Return the temporary file to use.'''
         if dir is None:
             dir = os.path.normpath(os.path.dirname(self._path))
-        kwargs['dir'] = dir
-        kwargs['delete'] = False
+        descriptor, name = tempfile.mkstemp(dir=dir)
+        # io.open() will take either the descriptor or the name, but we need
+        # the name later for commit()/replace_atomic() and couldn't find a way
+        # to get the filename from the descriptor.
+        os.close(descriptor)
         kwargs['mode'] = self._mode
-        return tempfile.NamedTemporaryFile(**kwargs)
+        kwargs['file'] = name
+        return io.open(**kwargs)
 
     def sync(self, f):
         '''responsible for clearing as many file caches as possible before

--- a/tests/test_atomicwrites.py
+++ b/tests/test_atomicwrites.py
@@ -10,11 +10,11 @@ def test_atomic_write(tmpdir):
     fname = tmpdir.join('ha')
     for i in range(2):
         with atomic_write(str(fname), overwrite=True) as f:
-            f.write('hoho')
+            f.write(u'hoho')
 
     with pytest.raises(OSError) as excinfo:
         with atomic_write(str(fname), overwrite=False) as f:
-            f.write('haha')
+            f.write(u'haha')
 
     assert excinfo.value.errno == errno.EEXIST
 
@@ -34,7 +34,7 @@ def test_teardown(tmpdir):
 def test_replace_simultaneously_created_file(tmpdir):
     fname = tmpdir.join('ha')
     with atomic_write(str(fname), overwrite=True) as f:
-        f.write('hoho')
+        f.write(u'hoho')
         fname.write('harhar')
         assert fname.read() == 'harhar'
     assert fname.read() == 'hoho'
@@ -45,7 +45,7 @@ def test_dont_remove_simultaneously_created_file(tmpdir):
     fname = tmpdir.join('ha')
     with pytest.raises(OSError) as excinfo:
         with atomic_write(str(fname), overwrite=False) as f:
-            f.write('hoho')
+            f.write(u'hoho')
             fname.write('harhar')
             assert fname.read() == 'harhar'
 
@@ -75,11 +75,11 @@ def test_atomic_write_in_pwd(tmpdir):
         fname = 'ha'
         for i in range(2):
             with atomic_write(str(fname), overwrite=True) as f:
-                f.write('hoho')
+                f.write(u'hoho')
 
         with pytest.raises(OSError) as excinfo:
             with atomic_write(str(fname), overwrite=False) as f:
-                f.write('haha')
+                f.write(u'haha')
 
         assert excinfo.value.errno == errno.EEXIST
 

--- a/tests/test_atomicwrites.py
+++ b/tests/test_atomicwrites.py
@@ -60,10 +60,10 @@ def test_open_reraise(tmpdir):
     fname = tmpdir.join('ha')
     with pytest.raises(AssertionError):
         with atomic_write(str(fname), overwrite=False) as f:
-            # Mess with f, so rollback will trigger an OSError. We're testing
+            # Mess with f, so commit will trigger a ValueError. We're testing
             # that the initial AssertionError triggered below is propagated up
-            # the stack, not the second exception triggered during rollback.
-            f.name = "asdf"
+            # the stack, not the second exception triggered during commit.
+            f.close()
             # Now trigger our own exception.
             assert False, "Intentional failure for testing purposes"
 


### PR DESCRIPTION
This enables users to pass any option supported by `tempfile.NamedTemporaryFile()` to `atomic_write()`. However, `mode`, `dir`, and `delete` continue to be overwritten as they were previously, to enforce the atomic write behavior.

Let me know if this approach is alright. I'm happy to adjust as needed.

Fixes #37 