### PR TITLE
Restore ability to use tempfile kwargs other than dir

### DIFF
--- a/atomicwrites/__init__.py
+++ b/atomicwrites/__init__.py
@@ -165,11 +165,13 @@ class AtomicWriter(object):
                 except Exception:
                     pass
 
-    def get_fileobject(self, dir=None, **kwargs):
+    def get_fileobject(self, suffix="", prefix=tempfile.template, dir=None,
+                       **kwargs):
         '''Return the temporary file to use.'''
         if dir is None:
             dir = os.path.normpath(os.path.dirname(self._path))
-        descriptor, name = tempfile.mkstemp(dir=dir)
+        descriptor, name = tempfile.mkstemp(suffix=suffix, prefix=prefix,
+                                            dir=dir)
         # io.open() will take either the descriptor or the name, but we need
         # the name later for commit()/replace_atomic() and couldn't find a way
         # to get the filename from the descriptor.


### PR DESCRIPTION
The changes in #38 broke the ability to use prefix, suffix and bufsize arguments when creating the tempfile. This  pull request restores the ability, and is intended to fix #39