### PR TITLE
Do not use deprecated template variable in tempfile module

### DIFF
--- a/atomicwrites/__init__.py
+++ b/atomicwrites/__init__.py
@@ -165,7 +165,7 @@ class AtomicWriter(object):
                 except Exception:
                     pass
 
-    def get_fileobject(self, suffix="", prefix=tempfile.template, dir=None,
+    def get_fileobject(self, suffix="", prefix=tempfile.gettempprefix(), dir=None,
                        **kwargs):
         '''Return the temporary file to use.'''
         if dir is None:

--- a/atomicwrites/__init__.py
+++ b/atomicwrites/__init__.py
@@ -165,8 +165,8 @@ class AtomicWriter(object):
                 except Exception:
                     pass
 
-    def get_fileobject(self, suffix="", prefix=tempfile.gettempprefix(), dir=None,
-                       **kwargs):
+    def get_fileobject(self, suffix="", prefix=tempfile.gettempprefix(),
+                       dir=None, **kwargs):
         '''Return the temporary file to use.'''
         if dir is None:
             dir = os.path.normpath(os.path.dirname(self._path))


### PR DESCRIPTION
Use gettempprefix() instead, as suggested by the documentation.