### PR TITLE
Add support for pathlib paths

### DIFF
--- a/atomicwrites/__init__.py
+++ b/atomicwrites/__init__.py
@@ -9,6 +9,12 @@ try:
 except ImportError:
     fcntl = None
 
+# `fspath` was added in Python 3.6
+try:
+    from os import fspath
+except ImportError:
+    fspath = None
+
 __version__ = '1.3.0'
 
 
@@ -136,6 +142,10 @@ class AtomicWriter(object):
             raise ValueError('Use the `overwrite`-parameter instead.')
         if 'w' not in mode:
             raise ValueError('AtomicWriters can only be written to.')
+
+        # Attempt to convert `path` to `str` or `bytes`
+        if fspath is not None:
+            path = fspath(path)
 
         self._path = path
         self._mode = mode


### PR DESCRIPTION
This adds support for `path` to be a `pathlib.Path` as described in #47.

As far as I could tell no docs or tests need to be updated to account for any of the changes since it's pretty minor. Tests and styling were checked with `tox` as described by CONTRIBUTING.