### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 os: linux
 language: python
 
@@ -9,6 +8,7 @@ python:
     - 3.5
     - 3.6
     - 3.7
+    - 3.8
 
 env:
     - TOXENV=test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,17 @@ build: false  # Not a C# project, build stuff at the test step instead.
 environment:
   matrix:
     - PYTHON: "C:/Python27"
+    - PYTHON: "C:/Python27-x64"
     - PYTHON: "C:/Python34"
+    - PYTHON: "C:/Python34-x64"
     - PYTHON: "C:/Python35"
+    - PYTHON: "C:/Python35-x64"
     - PYTHON: "C:/Python36"
+    - PYTHON: "C:/Python36-x64"
+    - PYTHON: "C:/Python37"
+    - PYTHON: "C:/Python37-x64"
+    - PYTHON: "C:/Python38"
+    - PYTHON: "C:/Python38-x64"
 
 init:
   - "ECHO %PYTHON%"

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,py,34,35,36}-{test,stylecheck}
+envlist = py{27,py,34,35,36,37,38}-{test,stylecheck}
 
 [testenv]
 deps =


### PR DESCRIPTION
Also...
- remove obsolete `sudo` keyword from Travis config
(https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)
- additionally use 64 bit interpreters on AppVeyor

This fixes #50 

P.S.: I have not dropped support for Python 3.4 yet, as I am not sure whether this is wanted at all.

modified:   .travis.yml
modified:   appveyor.yml
modified:   setup.py
modified:   tox.ini