### PR TITLE
add path_generator

### DIFF
--- a/atomicwrites/__init__.py
+++ b/atomicwrites/__init__.py
@@ -217,7 +217,7 @@ class AtomicWriter(object):
                         # path that was already attempted
                         raise ValueError(
                             'path_generator must return unique values, but'
-                            f'{path} was returned multiple times.'
+                            '{} was returned multiple times.'.format(path)
                         )
                     seen.add(path)
                     try:

--- a/atomicwrites/__init__.py
+++ b/atomicwrites/__init__.py
@@ -1,8 +1,8 @@
 import contextlib
 import io
 import os
-import sys
 import errno
+import sys
 import tempfile
 
 try:

--- a/atomicwrites/__init__.py
+++ b/atomicwrites/__init__.py
@@ -1,7 +1,7 @@
 import contextlib
+import errno
 import io
 import os
-import errno
 import sys
 import tempfile
 

--- a/atomicwrites/__init__.py
+++ b/atomicwrites/__init__.py
@@ -125,6 +125,12 @@ class AtomicWriter(object):
     :param overwrite: If set to false, an error is raised if ``path`` exists.
         Errors are only raised after the file has been written to.  Either way,
         the operation is atomic.
+    :param path_generator: A generator function that takes the `path` as an
+        argument and returns the next path to attempt to create.  If creation
+        fails, the generator will be repeatedly called to get the next path to
+        try writing until the write succeeds or the a previously attempted path
+        is generated again.  A `ValueError` is raised if a previously attempted
+        path is provided by the generator.
     :param open_kwargs: Keyword-arguments to pass to the underlying
         :py:func:`open` call. This can be used to set the encoding when opening
         files in text-mode.

--- a/atomicwrites/__init__.py
+++ b/atomicwrites/__init__.py
@@ -2,6 +2,7 @@ import contextlib
 import io
 import os
 import sys
+import errno
 import tempfile
 
 try:
@@ -133,7 +134,7 @@ class AtomicWriter(object):
     '''
 
     def __init__(self, path, mode=DEFAULT_MODE, overwrite=False,
-                 **open_kwargs):
+                 path_generator=None, **open_kwargs):
         if 'a' in mode:
             raise ValueError(
                 'Appending to an existing file is not supported, because that '
@@ -153,7 +154,9 @@ class AtomicWriter(object):
         self._path = path
         self._mode = mode
         self._overwrite = overwrite
+        self._path_generator = path_generator
         self._open_kwargs = open_kwargs
+        self.final_path = None
 
     def open(self):
         '''
@@ -169,10 +172,11 @@ class AtomicWriter(object):
             with get_fileobject(**self._open_kwargs) as f:
                 yield f
                 self.sync(f)
-            self.commit(f)
+            self.final_path = self.commit(f)
             success = True
         finally:
             if not success:
+                self.final_path = None
                 try:
                     self.rollback(f)
                 except Exception:
@@ -203,8 +207,31 @@ class AtomicWriter(object):
         '''Move the temporary file to the target location.'''
         if self._overwrite:
             replace_atomic(f.name, self._path)
+            return self._path
         else:
-            move_atomic(f.name, self._path)
+            if self._path_generator is not None:
+                seen = set()
+                for path in self._path_generator(self._path):
+                    if path in seen:
+                        # avoid infinite loop if the path generator returns a
+                        # path that was already attempted
+                        raise ValueError(
+                            'path_generator must return unique values, but'
+                            f'{path} was returned multiple times.'
+                        )
+                    seen.add(path)
+                    try:
+                        move_atomic(f.name, path)
+                    except OSError as exc:
+                        if exc.errno == errno.EEXIST:
+                            pass
+                        else:
+                            raise
+                    else:
+                        return path
+            else:
+                move_atomic(f.name, self._path)
+                return self._path
 
     def rollback(self, f):
         '''Clean up all temporary resources.'''


### PR DESCRIPTION
I have a python script that outputs file(s) to a specific directory and may be running on multiple computers within a cluster.  The output files should all be named like `name.#.csv` where `#` is an increasing number: 1, 2, 3, etc.  I don't want any files to be overwritten, but I also don't want the write to fail.  Instead, it should just increment the file number until the write succeeds.  I originally used a dumb loop when writing the file to find the next available file to use, but I'd run into race conditions with many processes running simultaneously and files would somewhat frequently get overwritten.

My solution was the edit I've added here as PR.  Basically it adds a "path generator" that should be a generator which sequentially returns the next filename to try.  This is flexible, as the user could make the generator return paths based on something entirely different than a sequential numbering.  With this, my script works great and I haven't seen anymore files getting overwritten, so I thought I'd add a PR in case others find it useful.  If not, feel free to just close this!

Here is an example of how I use it:

```python
import itertools
from atomicwrites import AtomicWriter

def file_incrementor(base_filename):
    for i in itertools.count(1):
        # change i to 1 to see error raised by library to avoid infinite loop
        yield base_filename.format(i)

writer = AtomicWriter(path='name.{}.csv', path_generator=file_incrementor)
with writer.open() as output:
    # calculations with intermittent writes to output
    output.write('example text')
# it also saves the actual path that was saved (regardless of whether path_generator was used)
print(writer.final_path)
```
